### PR TITLE
fix: 修复: 🧩 修复暗黑模式图标切换问题（实验）

### DIFF
--- a/components/DarkBtn.vue
+++ b/components/DarkBtn.vue
@@ -1,17 +1,16 @@
 <template>
-  <div class="cursor-pointer opacity-70 transition-opacity hover:opacity-100" @click="handleDark">
-    <!-- 
-      会发生水和问题，但使用ColorScheme和ClientOnly
-      解决了水和问题，
-      可是不能解决在vercel部署后图标请求丢失问题；（暂时无法解决）
-    -->
-    <Icon v-show="$colorMode.value === 'dark'" name="mingcute:moon-stars-line" size="24"></Icon>
-    <Icon v-show="$colorMode.value === 'light'" name="mingcute:sun-fill" size="24"></Icon>
-  </div>
+  <ClientOnly>
+    <div class="cursor-pointer opacity-70 transition-opacity hover:opacity-100" @click="handleDark">
+      <Icon v-if="isDark" name="mingcute:moon-stars-line" size="24"></Icon>
+      <Icon v-else name="mingcute:sun-fill" size="24"></Icon>
+    </div>
+  </ClientOnly>
 </template>
 
 <script lang="ts" setup>
 const colorMode = useColorMode();
+
+const isDark = computed(() => colorMode.preference === "dark");
 
 const handleDark = () => {
   colorMode.preference = colorMode.preference === "dark" ? "light" : "dark";


### PR DESCRIPTION
此请求包括对 `components/DarkBtn.vue` 文件的更改，以改进暗模式切换的处理并解决图标可见性问题。

对暗色模式处理的改进：

* 将暗模式切换按钮封装在一个 “ClientOnly ”组件中，以确保它仅在客户端渲染，从而防止出现水合问题。
* 使用计算属性 `isDark` 确定当前颜色模式，并使用 `v-if` 和 `v-else` 有条件地显示相应图标，从而简化了图标呈现逻辑。